### PR TITLE
The collective.folderishtypes package will not be installed by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.1.0a7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+Breaking:
+
+- The ``collective.folderishtypes`` package will not be installed by default
+  [ale-rt]
 
 
 3.1.0a6 (2021-11-22)

--- a/src/plone/volto/profiles/default/metadata.xml
+++ b/src/plone/volto/profiles/default/metadata.xml
@@ -2,7 +2,6 @@
 <metadata>
   <version>1012</version>
   <dependencies>
-    <dependency>profile-collective.folderishtypes.dx:default</dependency>
     <dependency>profile-plone.restapi:blocks</dependency>
   </dependencies>
 </metadata>


### PR DESCRIPTION
I am just experimenting :)
See https://github.com/plone/Plone/pull/20