### PR TITLE
Remove c.folderishtypes dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 3.1.0a7 (unreleased)
 --------------------
 
+Breaking:
+
+- Remove c.folderishtypes dependency
+  [sneridagh]
+
 Internal:
 
 - Test with Plone 6.0.0a2

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Products.GenericSetup",
         "setuptools",
         "plone.restapi>=8.13.0",
-        "collective.folderishtypes[dexterity]",
     ],
     extras_require={
         "test": [

--- a/src/plone/volto/content.py
+++ b/src/plone/volto/content.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from collective.folderishtypes.interfaces import IFolderishDocument
+from collective.folderishtypes.interfaces import IFolderishEvent
+from collective.folderishtypes.interfaces import IFolderishNewsItem
+from plone.app.contenttypes.interfaces import IDocument
+from plone.app.contenttypes.interfaces import IEvent
+from plone.app.contenttypes.interfaces import INewsItem
+from plone.dexterity.content import Container
+from zope.interface import implementer
+
+
+@implementer(IDocument, IFolderishDocument)
+class FolderishDocument(Container):
+    pass
+
+
+@implementer(IEvent, IFolderishEvent)
+class FolderishEvent(Container):
+    pass
+
+
+@implementer(INewsItem, IFolderishNewsItem)
+class FolderishNewsItem(Container):
+    pass

--- a/src/plone/volto/content.py
+++ b/src/plone/volto/content.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from collective.folderishtypes.interfaces import IFolderishDocument
-from collective.folderishtypes.interfaces import IFolderishEvent
-from collective.folderishtypes.interfaces import IFolderishNewsItem
+from plone.volto.interfaces import IFolderishDocument
+from plone.volto.interfaces import IFolderishEvent
+from plone.volto.interfaces import IFolderishNewsItem
 from plone.app.contenttypes.interfaces import IDocument
 from plone.app.contenttypes.interfaces import IEvent
 from plone.app.contenttypes.interfaces import INewsItem

--- a/src/plone/volto/dependencies.zcml
+++ b/src/plone/volto/dependencies.zcml
@@ -18,6 +18,5 @@
       />
   <include package="plone.restapi" />
   <include package="plone.api" />
-  <include package="collective.folderishtypes" />
 
 </configure>

--- a/src/plone/volto/interfaces.py
+++ b/src/plone/volto/interfaces.py
@@ -9,7 +9,6 @@ class IPloneVoltoCoreLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
 
 
-### bbb
 class IThemeSpecific(IPloneVoltoCoreLayer):
     """bbb for collective.folderishtypes browser interface."""
 

--- a/src/plone/volto/interfaces.py
+++ b/src/plone/volto/interfaces.py
@@ -17,3 +17,19 @@ class IVoltoSettings(Interface):
         description=u"Used for rewriting URL's sent in the password reset e-mail by Plone.",
         default="http://localhost:3000",
     )
+
+
+class IFolderishType(Interface):
+    """Marker interface"""
+
+
+class IFolderishDocument(IFolderishType):
+    """Marker interface"""
+
+
+class IFolderishEvent(IFolderishType):
+    """Marker interface"""
+
+
+class IFolderishNewsItem(IFolderishType):
+    """Marker interface"""

--- a/src/plone/volto/interfaces.py
+++ b/src/plone/volto/interfaces.py
@@ -9,6 +9,11 @@ class IPloneVoltoCoreLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
 
 
+### bbb
+class IThemeSpecific(IPloneVoltoCoreLayer):
+    """bbb for collective.folderishtypes browser interface."""
+
+
 class IVoltoSettings(Interface):
     """Volto settings necessary to store in the backend"""
 

--- a/src/plone/volto/patches.py
+++ b/src/plone/volto/patches.py
@@ -20,9 +20,9 @@ try:
     from collective.folderishtypes.dx import content  # noqa F401
 except ImportError:
     logger.info("Aliasing collective.folderish classes to plone.volto classes.")
-    alias_module('collective.folderishtypes.dx.content', content)
-    alias_module('collective.folderishtypes.dx.interfaces', interfaces)
-    alias_module('collective.folderishtypes.interfaces', interfaces)
+    alias_module("collective.folderishtypes.dx.content", content)
+    alias_module("collective.folderishtypes.dx.interfaces", interfaces)
+    alias_module("collective.folderishtypes.interfaces", interfaces)
 
 
 def _do_copy_to_zlog(self, now, strtype, entry_id, url, tb_text):

--- a/src/plone/volto/patches.py
+++ b/src/plone/volto/patches.py
@@ -1,3 +1,7 @@
+from plone.app.upgrade.utils import alias_module
+from plone.volto import logger
+from plone.volto import content
+from plone.volto import interfaces
 from plone.volto.interfaces import IVoltoSettings
 from plone.registry.interfaces import IRegistry
 from plone.rest.interfaces import IAPIRequest
@@ -10,6 +14,15 @@ import logging
 
 
 LOG = logging.getLogger("Zope.SiteErrorLog")
+
+
+try:
+    from collective.folderishtypes.dx import content  # noqa F401
+except ImportError:
+    logger.info("Aliasing collective.folderish classes to plone.volto classes.")
+    alias_module('collective.folderishtypes.dx.content', content)
+    alias_module('collective.folderishtypes.dx.interfaces', interfaces)
+    alias_module('collective.folderishtypes.interfaces', interfaces)
 
 
 def _do_copy_to_zlog(self, now, strtype, entry_id, url, tb_text):

--- a/src/plone/volto/profiles/default/metadata.xml
+++ b/src/plone/volto/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1012</version>
+  <version>1014</version>
   <dependencies>
     <dependency>profile-plone.restapi:blocks</dependency>
   </dependencies>

--- a/src/plone/volto/profiles/default/metadata.xml
+++ b/src/plone/volto/profiles/default/metadata.xml
@@ -2,7 +2,6 @@
 <metadata>
   <version>1012</version>
   <dependencies>
-    <dependency>profile-collective.folderishtypes.dx:default</dependency>
     <dependency>profile-plone.restapi:blocks</dependency>
   </dependencies>
 </metadata>

--- a/src/plone/volto/profiles/default/types.xml
+++ b/src/plone/volto/profiles/default/types.xml
@@ -3,4 +3,6 @@
   <object name="Plone Site" />
   <object meta_type="Dexterity FTI" name="LRF" />
   <object meta_type="Dexterity FTI" name="Document" />
+  <object meta_type="Dexterity FTI" name="News Item" />
+  <object meta_type="Dexterity FTI" name="Event" />
 </object>

--- a/src/plone/volto/profiles/default/types/Document.xml
+++ b/src/plone/volto/profiles/default/types/Document.xml
@@ -5,8 +5,12 @@
     name="Document"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
+  <property name="filter_content_types">False</property>
+  <property name="klass">plone.volto.content.FolderishDocument</property>
+
   <!-- Enabled behaviors -->
   <property name="behaviors">
+    <element value="plone.constraintypes"/>
     <element value="plone.namefromtitle" />
     <element value="plone.allowdiscussion" />
     <element value="plone.excludefromnavigation" />

--- a/src/plone/volto/profiles/default/types/Event.xml
+++ b/src/plone/volto/profiles/default/types/Event.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="Event" meta_type="Dexterity FTI" i18n:domain="plone"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="filter_content_types">False</property>
+  <property name="klass">plone.volto.content.FolderishEvent</property>
+  <property name="behaviors" purge="false">
+    <element value="plone.constraintypes"/>
+  </property>
+</object>

--- a/src/plone/volto/profiles/default/types/News_Item.xml
+++ b/src/plone/volto/profiles/default/types/News_Item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="News Item" meta_type="Dexterity FTI" i18n:domain="plone"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="filter_content_types">False</property>
+  <property name="klass">plone.volto.content.FolderishNewsItem</property>
+  <property name="behaviors" purge="false">
+    <element value="plone.constraintypes"/>
+  </property>
+</object>

--- a/src/plone/volto/upgrades.py
+++ b/src/plone/volto/upgrades.py
@@ -15,7 +15,9 @@ MIGRATION = {
 def migrate_content_classes(context):
     """Migrate content created with collective.folderishtypes to plone.volto."""
     interface = "collective.folderishtypes.interfaces.IFolderishType"
-    idxs = ["object_provides", ]
+    idxs = [
+        "object_provides",
+    ]
     brains = api.content.find(object_provides=interface)
     total_brains = len(brains)
     logger.info(f"Migration: {total_brains} contents to be migrated.")

--- a/src/plone/volto/upgrades.py
+++ b/src/plone/volto/upgrades.py
@@ -34,7 +34,7 @@ def migrate_content_classes(context):
         if idx and idx % 100 == 0:
             logger.info(f"Migration: {idx + 1} / {total_brains}")
 
-    logger.info(f"Migration from collective.folderishtypes to plone.volto complete")
+    logger.info("Migration from collective.folderishtypes to plone.volto complete")
 
 
 def from12to13_migrate_listings(context):

--- a/src/plone/volto/upgrades.py
+++ b/src/plone/volto/upgrades.py
@@ -3,6 +3,10 @@ from plone import api
 from plone.restapi.behaviors import IBlocks
 
 
+def migrate_content_classes(context):
+    pass
+
+
 def from12to13_migrate_listings(context):
     def migrate_listing(originBlocks):
         blocks = deepcopy(originBlocks)

--- a/src/plone/volto/upgrades.py
+++ b/src/plone/volto/upgrades.py
@@ -1,10 +1,38 @@
 from copy import deepcopy
 from plone import api
 from plone.restapi.behaviors import IBlocks
+from plone.volto import content
+from plone.volto import logger
+
+
+MIGRATION = {
+    "Document": content.FolderishDocument,
+    "Event": content.FolderishEvent,
+    "News Item": content.FolderishNewsItem,
+}
 
 
 def migrate_content_classes(context):
-    pass
+    """Migrate content created with collective.folderishtypes to plone.volto."""
+    interface = "collective.folderishtypes.interfaces.IFolderishType"
+    idxs = ["object_provides", ]
+    brains = api.content.find(object_provides=interface)
+    total_brains = len(brains)
+    logger.info(f"Migration: {total_brains} contents to be migrated.")
+    for idx, brain in enumerate(brains):
+        content = brain.getObject()
+        content_id = content.getId()
+        content.__class__ = MIGRATION[content.portal_type]
+        parent = content.aq_parent
+        parent._delOb(content_id)
+        parent._setOb(content_id, content)
+        content = parent[content_id]
+        content.reindexObject(idxs=idxs)
+
+        if idx and idx % 100 == 0:
+            logger.info(f"Migration: {idx + 1} / {total_brains}")
+
+    logger.info(f"Migration from collective.folderishtypes to plone.volto complete")
 
 
 def from12to13_migrate_listings(context):

--- a/src/plone/volto/upgrades.zcml
+++ b/src/plone/volto/upgrades.zcml
@@ -21,4 +21,20 @@
       import_steps="catalog"
       />
 
+    <genericsetup:upgradeDepends
+      title="Move from c.folderishtypes to local"
+      profile="plone.volto:default"
+      source="1012"
+      destination="1013"
+      import_steps="typeinfo"
+      />
+
+    <genericsetup:upgradeStep
+      title="Migrate existing content classes from old c.folderishtypes to local"
+      profile="plone.volto:default"
+      source="1013"
+      destination="1014"
+      handler=".upgrades.migrate_content_classes"
+      />
+
 </configure>

--- a/src/plone/volto/upgrades.zcml
+++ b/src/plone/volto/upgrades.zcml
@@ -21,7 +21,7 @@
       import_steps="catalog"
       />
 
-    <genericsetup:upgradeDepends
+  <genericsetup:upgradeDepends
       title="Move from c.folderishtypes to local"
       profile="plone.volto:default"
       source="1012"
@@ -29,7 +29,7 @@
       import_steps="typeinfo"
       />
 
-    <genericsetup:upgradeStep
+  <genericsetup:upgradeStep
       title="Migrate existing content classes from old c.folderishtypes to local"
       profile="plone.volto:default"
       source="1013"


### PR DESCRIPTION
@ale-rt Done, migrated away from c.folderishtypes. 

Now we need now the migration script from `collective.folderishtypes.dx.content.x` to `plone.volto.content.x` of the existing content. Do you know an accepted and reliable way for doing this? Any pointer?