### PR TITLE
Bring back the draftJS as default, until Slate is integrated in full …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Bring back the draftJS as default, until Slate is integrated in full in Volto
+  [sneridagh]
 
 
 4.0.0a1 (2022-01-25)

--- a/README.rst
+++ b/README.rst
@@ -121,10 +121,10 @@ e.g. in your GS ``metadata.xml`` along with your other dependencies::
   </dependencies>
   </metadata>
 
-**NOTE**: From ``plone.volto`` above version 4.0.0, the default block for creating the
-default content in the root (or corresponding Language Root Folders) is "slate". If you
-want still to create draftJS blocks, you need to use the ``default-homepage-drafjs`` profile.
-
+**NOTE**: The default block for creating the default content in the root (or
+corresponding Language Root Folders) is "draftJS" text block. ``plone.volto`` provides a
+profile if you want to create Slate blocks: you need to use the ``default-homepage-slate``
+profile.
 
 Document Content Type
 ---------------------

--- a/src/plone/volto/profiles.zcml
+++ b/src/plone/volto/profiles.zcml
@@ -29,7 +29,7 @@
       description="Creates a default page for the site"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/homepage"
-      post_handler=".setuphandlers.create_default_homepage"
+      post_handler=".setuphandlers.create_default_homepage_draftjs"
       />
 
   <genericsetup:registerProfile
@@ -39,6 +39,15 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/homepage"
       post_handler=".setuphandlers.create_default_homepage_draftjs"
+      />
+
+  <genericsetup:registerProfile
+      name="default-homepage-slate"
+      title="Plone 6 Frontend (Default content on homepage with slate blocks)"
+      description="Creates a default page for the site using slate blocks"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/homepage"
+      post_handler=".setuphandlers.create_default_homepage_slate"
       />
 
   <genericsetup:registerProfile

--- a/src/plone/volto/setuphandlers.py
+++ b/src/plone/volto/setuphandlers.py
@@ -219,6 +219,10 @@ def create_default_homepage_draftjs(context):
     create_default_homepage(context, block_type="draftJS")
 
 
+def create_default_homepage_slate(context):
+    create_default_homepage(context, block_type="slate")
+
+
 def create_default_homepage(context, default_home=default_lrf_home, block_type=None):
     """This method allows to pass a dict with the homepage blocks and blocks_layout keys"""
     portal = api.portal.get()


### PR DESCRIPTION
…in Volto.

@mauritsvanrees Please hold 6.0.0a3 until this is settled. (if possible)