### PR TITLE
Simplify the nested block resolveuid transforms

### DIFF
--- a/news/76.bugfix
+++ b/news/76.bugfix
@@ -1,0 +1,2 @@
+Fix the handler for resolving UIDs in nested blocks to avoid trying to resolve them twice. This also makes it possible to use deserialization and serialization transforms that intentionally run before the resolveuid transform in the context of nested blocks.
+[davisagli]

--- a/src/plone/volto/configure.zcml
+++ b/src/plone/volto/configure.zcml
@@ -76,6 +76,22 @@
         factory=".transforms.NestedResolveUIDSerializerRoot"
         provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
         />
+    <subscriber
+        factory=".transforms.PreviewImageResolveUIDDeserializer"
+        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
+        />
+    <subscriber
+        factory=".transforms.PreviewImageResolveUIDDeserializerRoot"
+        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
+        />
+    <subscriber
+        factory=".transforms.PreviewImageResolveUIDSerializer"
+        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
+        />
+    <subscriber
+        factory=".transforms.PreviewImageResolveUIDSerializerRoot"
+        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
+        />
   </configure>
 
 </configure>

--- a/src/plone/volto/tests/test_transforms.py
+++ b/src/plone/volto/tests/test_transforms.py
@@ -57,15 +57,25 @@ class TestBlocksTransforms(unittest.TestCase):
             blocks={
                 "123": {
                     "@type": "teaserGrid",
-                    "columns": [{"href": self.portal.doc1.absolute_url()}],
+                    "columns": [
+                        {
+                            "href": self.portal.doc1.absolute_url(),
+                            "preview_image": self.image.absolute_url(),
+                        }
+                    ],
                 }
             }
         )
         doc_uid = IUUID(self.portal.doc1)
+        image_uid = IUUID(self.image)
 
         self.assertEqual(
             self.portal.doc1.blocks["123"]["columns"][0]["href"],
             "../resolveuid/{}".format(doc_uid),
+        )
+        self.assertEqual(
+            self.portal.doc1.blocks["123"]["columns"][0]["preview_image"],
+            "../resolveuid/{}".format(image_uid),
         )
 
     def test_deserialize_nested_fields_arrayed_resolveuid(self):
@@ -102,18 +112,27 @@ class TestBlocksTransforms(unittest.TestCase):
 
     def test_serialize_nested_fields_resolveuid(self):
         doc_uid = IUUID(self.portal.doc1)
+        image_uid = IUUID(self.image)
         value = self.serialize(
             context=self.portal.doc1,
             blocks={
                 "123": {
                     "@type": "teaserGrid",
-                    "columns": [{"href": "../resolveuid/{}".format(doc_uid)}],
+                    "columns": [
+                        {
+                            "href": "../resolveuid/{}".format(doc_uid),
+                            "preview_image": "../resolveuid/{}".format(image_uid),
+                        }
+                    ],
                 }
             },
         )
 
         self.assertEqual(
             value["123"]["columns"][0]["href"], self.portal.doc1.absolute_url()
+        )
+        self.assertEqual(
+            value["123"]["columns"][0]["preview_image"], self.image.absolute_url()
         )
 
     def test_serialize_nested_fields_arrayed_resolveuid(self):


### PR DESCRIPTION
NestedResolveUIDDeserializerBase and NestedResolveUIDSerializerBase were implemented in a way that duplicated code from plone.restapi and ran the transform twice. Fixing this to simplify the code and make it possible to register transforms that run _before_ the resolveuid transform.