### PR TITLE
fix indexers when there is a broken preview_image_link

### DIFF
--- a/news/91.bugfix
+++ b/news/91.bugfix
@@ -1,0 +1,2 @@
+- Fix hasPreviewImage and image_field indexers when the preview_image_link
+  relation is broken. [davisagli]

--- a/src/plone/volto/indexers.py
+++ b/src/plone/volto/indexers.py
@@ -10,7 +10,9 @@ def hasPreviewImage(obj):
     Indexer for knowing in a catalog search if a content with the IPreview behavior has
     a preview_image
     """
-    if obj.aq_base.preview_image or obj.aq_base.preview_image_link:
+    if obj.aq_base.preview_image or (
+        obj.aq_base.preview_image_link and not obj.preview_image_link.isBroken()
+    ):
         return True
     return False
 
@@ -23,7 +25,10 @@ def image_field_indexer(obj):
     image_field = ""
     if getattr(base_obj, "preview_image", False):
         image_field = "preview_image"
-    elif getattr(base_obj, "preview_image_link", False):
+    elif (
+        getattr(base_obj, "preview_image_link", False)
+        and not base_obj.preview_image_link.isBroken()
+    ):
         image_field = "preview_image_link"
     elif getattr(base_obj, "image", False):
         image_field = "image"


### PR DESCRIPTION
When an object that is the target of a RelationChoice field is deleted, the object that is the source still has a RelationValue which evaluates to True in a boolean context, but the relation value is marked as broken. These indexers need to check for that so that they don't indicate the item has a preview image if the related image was deleted.