### PR TITLE
Adjust Plone site actions for Volto

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,1 @@
+Adjust Plone site actions to work in Volto. [nileshgulia1, davisagli]

--- a/src/plone/volto/profiles/default/actions.xml
+++ b/src/plone/volto/profiles/default/actions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Plone Actions Tool"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="site_actions"
+  >
+    <object meta_type="CMF Action"
+            name="accessibility"
+            i18n:domain="plone"
+    >
+      <property name="visible">False</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="contact"
+            i18n:domain="plone"
+    >
+      <property name="url_expr">python:f"{plone_portal_state.navigation_root_url()}/contact-form"</property>
+    </object>
+  </object>
+</object>


### PR DESCRIPTION
Adjust some of Plone's site actions to work in Volto:
- hide the accessibility-info action, since it's not implemented in Volto
- change the URL for the contact form from `contact-info` to `contact-form`, since the latter is the route used in Volto

This is needed so that we can merge https://github.com/plone/volto/pull/3248 and still have footer links that make sense.

This PR replaces #64 