### PR TITLE
Improve @@migrate_to_volto wizard wording, update 6.dev-docs

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,4 @@
+Clarifications in the @@migrate_to_volto wizard. Volto is a separate service that needs to be configured and hosted. It is not included in the Plone backend.
+Editing the main content that was in RichText fields before will no longer be possible after migration.
+Fix link to Volto frontend documentation.
+[fredvd, stevepiercy]

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -25,7 +25,7 @@
     <p i18n:translate="">When you click on "Migrate to Volto" at the end of the form, the following things will happen:</p>
     <ol>
         <li i18n:translate="">Install the package <code>plone.volto</code> and <code>plone.restapi</code>.</li>
-        <li i18n:translate="">The HTML of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
+        <li i18n:translate="">The HTML of RichText fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
         <li i18n:translate="">Pages, News Items, and Events are made folderish. That means they can contain other content, such as Images or Pages.</li>
         <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder wherever that is possible.
             This works well with Pages and Collections where the text and/or query are added to the folderish page that replaces the Folder.</li>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -33,7 +33,7 @@
     </ol>
 
     <p i18n:translate="">A site migrated to Volto in this Plone backend will still be accessible through the Plone Classic User Interface but with
-                         limited functionality. The core contenttypes wil have all their graphical RichText fields replaced by the blocks behavior for
+                         limited functionality. The core content types will have all their GUI RichText fields replaced by the blocks behavior for
                          the composition of the main content. So after migration you can only edit this content using the Volto UI.</p>
 
     <form id="migrate_to_volto" action="@@migrate_to_volto" tal:attributes="action request/URL" method="post" enctype="multipart/form-data">

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -13,7 +13,7 @@
     <p class="lead" i18n:translate="">Here you can prepare this site for Volto.</p>
 
     <h3 i18n:translate="">What is Volto?</h3>
-    <p i18n:translate="">Volto is a React-based frontend for Plone. It is the default UI for Plone 6. Volto is a separate server side application.</p>
+    <p i18n:translate="">Volto is a React-based frontend for Plone. It is the default UI for Plone 6. Volto is a separate server-side application.</p>
 
     <h3 i18n:translate="">What do you need for Volto?</h3>
     <p i18n:translate="">Volto needs to run continuously alongside the current Plone backend service from which you access this wizard. The Volto 

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -26,7 +26,7 @@
     <ol>
         <li i18n:translate="">Install the package <code>plone.volto</code> and <code>plone.restapi</code>.</li>
         <li i18n:translate="">The html of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
-        <li i18n:translate="">Pages, News Items and Events are made folderish. That means they can contain other content like Images or Pages.</li>
+        <li i18n:translate="">Pages, News Items, and Events are made folderish. That means they can contain other content, such as Images or Pages.</li>
         <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder whereever that is possible.
             This works well with Pages and Collections where the text and/or query are added to the folderish page that replaces the Folder.</li>
         <li i18n:translate="">Collections are migrated to Pages with Listing Blocks configured like the Collection.</li>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -27,7 +27,7 @@
         <li i18n:translate="">Install the package <code>plone.volto</code> and <code>plone.restapi</code>.</li>
         <li i18n:translate="">The html of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
         <li i18n:translate="">Pages, News Items, and Events are made folderish. That means they can contain other content, such as Images or Pages.</li>
-        <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder whereever that is possible.
+        <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder wherever that is possible.
             This works well with Pages and Collections where the text and/or query are added to the folderish page that replaces the Folder.</li>
         <li i18n:translate="">Collections are migrated to Pages with Listing Blocks configured like the Collection.</li>
     </ol>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -13,15 +13,16 @@
     <p class="lead" i18n:translate="">Here you can prepare this site for Volto.</p>
 
     <h3 i18n:translate="">What is Volto?</h3>
-    <p i18n:translate="">Volto is a React-based frontend for Plone. It is the default UI for Plone 6.</p>
+    <p i18n:translate="">Volto is a React-based frontend for Plone. It is the default UI for Plone 6. Volto is a separate server side application.</p>
 
-    <h3 i18n:translate="">What do you need?</h3>
-    <p i18n:translate="">Volto is a separate server side application. It needs to run continuously alongside the current Plone backend service from which you
-                         loaded this wizard. The Volto server performs initial server side rendering (SSR) of the React application and delivers the javascript frontend to your browser. 
-                         Without a Volto frontend prepared for your website and the means to host it, continuing this migration makes no sense!
-           
+    <h3 i18n:translate="">What do you need for Volto?</h3>
+    <p i18n:translate="">Volto needs to run continuously alongside the current Plone backend service from which you access this wizard. The Volto 
+                         server performs initial server side rendering (SSR) of the React application for pages. It also delivers the javascript frontend
+                         to your browser. Without a Volto frontend prepared for this website and the means to host it, continuing this migration makes no
+                         sense! Read the <a href="https://6.docs.plone.org/volto/index.html">Volto Frontend documentation</a> for more information.</p>
+
     <h3 i18n:translate="">What will happen?</h3>
-    <p i18n:translate="">When you click on "Migrate to Volto" the following things will happen:</p>
+    <p i18n:translate="">When you click on "Migrate to Volto" at the end of the form, the following things will happen:</p>
     <ol>
         <li i18n:translate="">Install the package <code>plone.volto</code> and <code>plone.restapi</code>.</li>
         <li i18n:translate="">The html of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
@@ -33,18 +34,13 @@
 
     <p i18n:translate="">A site migrated to Volto in this Plone backend will still be accessible through the Plone Classic User Interface but with
                          limited functionality. The core contenttypes wil have all their graphical RichText fields replaced by the blocks behavior for
-                         the composition of the main content layout. So you can only edit this content using the Volto UI.</p>
+                         the composition of the main content. So after migration you can only edit this content using the Volto UI.</p>
 
     <form id="migrate_to_volto" action="@@migrate_to_volto" tal:attributes="action request/URL" method="post" enctype="multipart/form-data">
 
-        <div class="formControls form-group">
-            <input type="hidden" name="form.submitted" value="1"/>
-            <button class="btn btn-primary submit-widget button-field context"
-                    type="submit" name="submit" value="export">Migrate to Volto
-            </button>
-        </div>
 
-        <h3 i18n:translate="" class="mt-5">Requirements</h3>
+
+        <h3 i18n:translate="" class="mt-5">Requirements for this migration wizard</h3>
         <ul>
             <li i18n:translate="">
             To migrate Richtext to Volto Blocks you need to have <code>blocks-conversion-tool</code> running on a accessible url.
@@ -116,6 +112,13 @@
             The migration requires a service to run. See https://github.com/plone/blocks-conversion-tool for details.
             </div>
 
+        </div>
+
+        <div class="formControls form-group">
+            <input type="hidden" name="form.submitted" value="1"/>
+            <button class="btn btn-primary submit-widget button-field context"
+                    type="submit" name="submit" value="export">Migrate to Volto
+            </button>
         </div>
 
     </form>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -17,7 +17,7 @@
 
     <h3 i18n:translate="">What do you need for Volto?</h3>
     <p i18n:translate="">Volto needs to run continuously alongside the current Plone backend service from which you access this wizard. The Volto 
-                         server performs initial server side rendering (SSR) of the React application for pages. It also delivers the javascript frontend
+                         server performs initial server-side rendering (SSR) of the React application for pages. It also delivers the JavaScript frontend
                          to your browser. Without a Volto frontend prepared for this website and the means to host it, continuing this migration makes no
                          sense! Read the <a href="https://6.docs.plone.org/volto/index.html">Volto Frontend documentation</a> for more information.</p>
 

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -43,7 +43,7 @@
         <h3 i18n:translate="" class="mt-5">Requirements for this migration wizard</h3>
         <ul>
             <li i18n:translate="">
-            To migrate Richtext to Volto Blocks you need to have <code>blocks-conversion-tool</code> running on a accessible url.
+            To migrate Richtext to Volto Blocks you need to have <code>blocks-conversion-tool</code> running on an accessible URL.
             The easiest way to have that running on your machine is: <code>docker run -it -p 5000:5000 plone/blocks-conversion-tool:latest</code>.
             More for options read <a href="https://github.com/plone/blocks-conversion-tool">https://github.com/plone/blocks-conversion-tool</a>.
             </li>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -15,6 +15,11 @@
     <h3 i18n:translate="">What is Volto?</h3>
     <p i18n:translate="">Volto is a React-based frontend for Plone. It is the default UI for Plone 6.</p>
 
+    <h3 i18n:translate="">What do you need?</h3>
+    <p i18n:translate="">Volto is a separate server side application. It needs to run continuously alongside the current Plone backend service from which you
+                         loaded this wizard. The Volto server performs initial server side rendering (SSR) of the React application and delivers the javascript frontend to your browser. 
+                         Without a Volto frontend prepared for your website and the means to host it, continuing this migration makes no sense!
+           
     <h3 i18n:translate="">What will happen?</h3>
     <p i18n:translate="">When you click on "Migrate to Volto" the following things will happen:</p>
     <ol>
@@ -22,10 +27,13 @@
         <li i18n:translate="">The html of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
         <li i18n:translate="">Pages, News Items and Events are made folderish. That means they can contain other content like Images or Pages.</li>
         <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder whereever that is possible.
-            This works well with Pages and Collections where the text and/or query are added to the folderish page that repalces the Folder.</li>
+            This works well with Pages and Collections where the text and/or query are added to the folderish page that replaces the Folder.</li>
         <li i18n:translate="">Collections are migrated to Pages with Listing Blocks configured like the Collection.</li>
-        <li i18n:translate="">A migrated site will still work in Plone Classic but behave different. Editors can only work with the Data using Volto.</li>
     </ol>
+
+    <p i18n:translate="">A site migrated to Volto in this Plone backend will still be accessible through the Plone Classic User Interface but with
+                         limited functionality. The core contenttypes wil have all their graphical RichText fields replaced by the blocks behavior for
+                         the composition of the main content layout. So you can only edit this content using the Volto UI.</p>
 
     <form id="migrate_to_volto" action="@@migrate_to_volto" tal:attributes="action request/URL" method="post" enctype="multipart/form-data">
 

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -25,7 +25,7 @@
     <p i18n:translate="">When you click on "Migrate to Volto" at the end of the form, the following things will happen:</p>
     <ol>
         <li i18n:translate="">Install the package <code>plone.volto</code> and <code>plone.restapi</code>.</li>
-        <li i18n:translate="">The html of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
+        <li i18n:translate="">The HTML of Richtext-Fields (previously edited using TinyMCE) is converted into Volto blocks so you can edit it in Volto.</li>
         <li i18n:translate="">Pages, News Items, and Events are made folderish. That means they can contain other content, such as Images or Pages.</li>
         <li i18n:translate="">Default Pages of Folders are merged with the Folderish Pages that replace the Folder wherever that is possible.
             This works well with Pages and Collections where the text and/or query are added to the folderish page that replaces the Folder.</li>

--- a/src/plone/volto/browser/migrate_to_volto.pt
+++ b/src/plone/volto/browser/migrate_to_volto.pt
@@ -43,7 +43,7 @@
         <h3 i18n:translate="" class="mt-5">Requirements for this migration wizard</h3>
         <ul>
             <li i18n:translate="">
-            To migrate Richtext to Volto Blocks you need to have <code>blocks-conversion-tool</code> running on an accessible URL.
+            To migrate RichText to Volto Blocks you need to have <code>blocks-conversion-tool</code> running on an accessible URL.
             The easiest way to have that running on your machine is: <code>docker run -it -p 5000:5000 plone/blocks-conversion-tool:latest</code>.
             More for options read <a href="https://github.com/plone/blocks-conversion-tool">https://github.com/plone/blocks-conversion-tool</a>.
             </li>

--- a/src/plone/volto/browser/voltobackendwarning.pt
+++ b/src/plone/volto/browser/voltobackendwarning.pt
@@ -8,7 +8,7 @@
         <span class="content">
             <tal:warning i18n:translate="volto_backend_warning">This site is configured to use the Volto frontend. You are accessing the backend.</tal:warning>
             <br />
-            <tal:warning i18n:translate="volto_backend_warning_link">For more information, please read the <a href="https://6.dev-docs.plone.org/volto/index.html">documentation</a>.</tal:warning>
+            <tal:warning i18n:translate="volto_backend_warning_link">For more information, please read the <a href="https://6.docs.plone.org/volto/index.html">documentation</a>.</tal:warning>
         </span>
     </div>
 


### PR DESCRIPTION
Change link to 6.dev-docs. to 6.docs.  in alert viewlet
Add paragraph to migration wizard that Volto is a separate application you need to install and host. 
Add link to same docs for Volto Frontend.
Improve impaired functionality in Classic UI text.
Move migrate button to the bottom of the page where everybody expects it

My main concern with the previous text is that it becomes nowhere clear for readers that Volto is a separate application and not a feature that is delivered through the Plone backend they are currently viewing.  Also the migrate_to_volto wizard is only one link away on the normal upgrade page. 

Inexperienced admins might think this is a easy peasy upgrade that needs to be done after upgrading a Plone 5.2 site with the 5.2 to 6 upgrade steps. 

<img width="780" alt="Link to wizard" src="https://user-images.githubusercontent.com/394784/207415997-447105fd-fdd6-4c8f-8845-6d2434c1a4c6.png">
