### PR TITLE
Retrieve internal links from nested blocks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10"]
-        plone: ["6.0.0b3", "5.2.9"]
+        python: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        plone: ["6.0.0", "5.2.10"]
         exclude:
-          - plone: "6.0.0b3"
+          - plone: "6.0.0"
             python: 3.7
-          - plone: "5.2.9"
+          - plone: "5.2.10"
             python: 3.9
-          - plone: "5.2.9"
+          - plone: "5.2.10"
             python: "3.10"
+          - plone: "5.2.10"
+            python: "3.11"
 
     steps:
       # git checkout

--- a/news/108.bugfix
+++ b/news/108.bugfix
@@ -1,0 +1,1 @@
+Include internal links from nested blocks in link integrity recordkeeping. [davisagli]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.2.9/versions.cfg
+    http://dist.plone.org/release/5.2.10/versions.cfg
 find-links += http://dist.plone.org/thirdparty/
 
 [versions]

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.0.0b3/versions.cfg
+    https://dist.plone.org/release/6.0.0/versions.cfg
     base.cfg
 
 [instance]

--- a/src/plone/volto/configure.zcml
+++ b/src/plone/volto/configure.zcml
@@ -92,6 +92,11 @@
         factory=".transforms.PreviewImageResolveUIDSerializerRoot"
         provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
         />
+
+    <subscriber
+        factory=".linkintegrity.NestedBlockLinkRetriever"
+        provides="plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever"
+        />
   </configure>
 
 </configure>

--- a/src/plone/volto/linkintegrity.py
+++ b/src/plone/volto/linkintegrity.py
@@ -1,0 +1,46 @@
+from plone.restapi.behaviors import IBlocks
+from plone.restapi.interfaces import IBlockFieldLinkIntegrityRetriever
+from zope.component import adapter
+from zope.component import subscribers
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+
+@adapter(IBlocks, IBrowserRequest)
+@implementer(IBlockFieldLinkIntegrityRetriever)
+class NestedBlockLinkRetriever:
+    """Retrieve internal links from nested blocks.
+
+    Handles the same keys as the resolveuid transform
+    (columns, hrefList, and slides)
+    """
+
+    order = 2
+    block_type = None  # any block type
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, block):
+        links = set()
+        for nested_name in ["columns", "hrefList", "slides"]:
+            nested_blocks = block.get(nested_name, [])
+            if not isinstance(nested_blocks, list):
+                continue
+            for nested_block in nested_blocks:
+                links |= self.retrieveLinks(nested_block)
+
+    def retrieveLinks(self, block):
+        links = set()
+        block_type = block.get("@type", None)
+        handlers = []
+        for h in subscribers(
+            (self.context, self.request),
+            IBlockFieldLinkIntegrityRetriever,
+        ):
+            if h.block_type == block_type or h.block_type is None:
+                handlers.append(h)
+        for handler in sorted(handlers, key=lambda h: h.order):
+            links |= set(handler(block))
+        return links

--- a/src/plone/volto/linkintegrity.py
+++ b/src/plone/volto/linkintegrity.py
@@ -30,6 +30,7 @@ class NestedBlockLinkRetriever:
                 continue
             for nested_block in nested_blocks:
                 links |= self.retrieveLinks(nested_block)
+        return links
 
     def retrieveLinks(self, block):
         links = set()

--- a/src/plone/volto/linkintegrity.py
+++ b/src/plone/volto/linkintegrity.py
@@ -24,7 +24,7 @@ class NestedBlockLinkRetriever:
 
     def __call__(self, block):
         links = set()
-        for nested_name in ["columns", "hrefList", "slides"]:
+        for nested_name in ("columns", "hrefList", "slides"):
             nested_blocks = block.get(nested_name, [])
             if not isinstance(nested_blocks, list):
                 continue

--- a/src/plone/volto/tests/test_linkintegrity.py
+++ b/src/plone/volto/tests/test_linkintegrity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.app.linkintegrity.interfaces import IRetriever
-from plone.volto.testing import PLONE_VOLTO_CORE_INTEGRATION_TESTING
 from plone.uuid.interfaces import IUUID
+from plone.volto.testing import PLONE_VOLTO_CORE_INTEGRATION_TESTING
 from unittest import TestCase
 
 

--- a/src/plone/volto/tests/test_linkintegrity.py
+++ b/src/plone/volto/tests/test_linkintegrity.py
@@ -34,11 +34,7 @@ class TestBlocksLinkintegrity(TestCase):
                 "columns": [
                     {
                         "@type": "teaser",
-                        "href": [
-                            {
-                                "@id": f"../resolveuid/{uid}",
-                            }
-                        ],
+                        "href": f"../resolveuid/{uid}",
                     }
                 ],
             },
@@ -55,11 +51,7 @@ class TestBlocksLinkintegrity(TestCase):
             "111": {
                 "hrefList": [
                     {
-                        "href": [
-                            {
-                                "@id": f"../resolveuid/{uid}",
-                            }
-                        ],
+                        "href": f"../resolveuid/{uid}",
                     }
                 ],
             },
@@ -76,11 +68,7 @@ class TestBlocksLinkintegrity(TestCase):
             "111": {
                 "slides": [
                     {
-                        "href": [
-                            {
-                                "@id": f"../resolveuid/{uid}",
-                            }
-                        ],
+                        "href": f"../resolveuid/{uid}",
                     }
                 ],
             },

--- a/src/plone/volto/tests/test_linkintegrity.py
+++ b/src/plone/volto/tests/test_linkintegrity.py
@@ -31,14 +31,16 @@ class TestBlocksLinkintegrity(TestCase):
         blocks = {
             "111": {
                 "@type": "__grid",
-                "columns": {
-                    "@type": "teaser",
-                    "href": [
-                        {
-                            "@id": f"../resolveuid/{uid}",
-                        }
-                    ],
-                },
+                "columns": [
+                    {
+                        "@type": "teaser",
+                        "href": [
+                            {
+                                "@id": f"../resolveuid/{uid}",
+                            }
+                        ],
+                    }
+                ],
             },
         }
         self.portal.doc1.blocks = blocks
@@ -51,13 +53,15 @@ class TestBlocksLinkintegrity(TestCase):
         uid = IUUID(self.doc2)
         blocks = {
             "111": {
-                "hrefList": {
-                    "href": [
-                        {
-                            "@id": f"../resolveuid/{uid}",
-                        }
-                    ],
-                },
+                "hrefList": [
+                    {
+                        "href": [
+                            {
+                                "@id": f"../resolveuid/{uid}",
+                            }
+                        ],
+                    }
+                ],
             },
         }
         self.portal.doc1.blocks = blocks
@@ -70,13 +74,15 @@ class TestBlocksLinkintegrity(TestCase):
         uid = IUUID(self.doc2)
         blocks = {
             "111": {
-                "slides": {
-                    "href": [
-                        {
-                            "@id": f"../resolveuid/{uid}",
-                        }
-                    ],
-                },
+                "slides": [
+                    {
+                        "href": [
+                            {
+                                "@id": f"../resolveuid/{uid}",
+                            }
+                        ],
+                    }
+                ],
             },
         }
         self.portal.doc1.blocks = blocks

--- a/src/plone/volto/tests/test_linkintegrity.py
+++ b/src/plone/volto/tests/test_linkintegrity.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from plone.app.linkintegrity.interfaces import IRetriever
+from plone.volto.testing import PLONE_VOLTO_CORE_INTEGRATION_TESTING
+from plone.uuid.interfaces import IUUID
+from unittest import TestCase
+
+
+class TestBlocksLinkintegrity(TestCase):
+    layer = PLONE_VOLTO_CORE_INTEGRATION_TESTING
+    maxDiff = None
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+        self.doc1 = self.portal[
+            self.portal.invokeFactory(
+                "Document", id="doc1", title="Document with Blocks"
+            )
+        ]
+        self.doc2 = self.portal[
+            self.portal.invokeFactory("Document", id="doc2", title="Target Document")
+        ]
+
+    def retrieve_links(self, value):
+        retriever = IRetriever(self.portal.doc1)
+        return retriever.retrieveLinks()
+
+    def test_links_retriever_return_internal_links_in_nested_columns(self):
+        uid = IUUID(self.doc2)
+        blocks = {
+            "111": {
+                "@type": "__grid",
+                "columns": {
+                    "@type": "teaser",
+                    "href": [
+                        {
+                            "@id": f"../resolveuid/{uid}",
+                        }
+                    ],
+                },
+            },
+        }
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 1)
+        self.assertIn(f"../resolveuid/{uid}", value)
+
+    def test_links_retriever_return_internal_links_in_nested_hrefList(self):
+        uid = IUUID(self.doc2)
+        blocks = {
+            "111": {
+                "hrefList": {
+                    "href": [
+                        {
+                            "@id": f"../resolveuid/{uid}",
+                        }
+                    ],
+                },
+            },
+        }
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 1)
+        self.assertIn(f"../resolveuid/{uid}", value)
+
+    def test_links_retriever_return_internal_links_in_nested_slides(self):
+        uid = IUUID(self.doc2)
+        blocks = {
+            "111": {
+                "slides": {
+                    "href": [
+                        {
+                            "@id": f"../resolveuid/{uid}",
+                        }
+                    ],
+                },
+            },
+        }
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 1)
+        self.assertIn(f"../resolveuid/{uid}", value)

--- a/src/plone/volto/tests/test_preview_link_behavior.py
+++ b/src/plone/volto/tests/test_preview_link_behavior.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from plone.dexterity.schema import invalidate_cache
 from plone.namedfile.file import NamedBlobImage
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.volto.testing import PLONE_6
@@ -32,6 +33,7 @@ class TestPreviewLinkBehavior(unittest.TestCase):
 
         fti = self.portal.portal_types.Document
         fti.behaviors += ("volto.preview_image_link",)
+        invalidate_cache(fti)
 
         self.doc = self.portal[self.portal.invokeFactory("Document", id="doc1")]
         self.image = self.portal[


### PR DESCRIPTION
Handle retrieving internal links for linkintegrity checks from the same locations in block data that are supported by the resolveuid transform.