### PR TITLE
Add numberOfFolderishDocuments to catalog metadata

### DIFF
--- a/news/numberOfFolderishDocuments.feature
+++ b/news/numberOfFolderishDocuments.feature
@@ -1,0 +1,2 @@
+- Add numberOfFolderishDocuments catalog metadata to allow UX affordance in folder contents in Volto.
+  [jaroel]

--- a/src/plone/volto/configure.zcml
+++ b/src/plone/volto/configure.zcml
@@ -46,6 +46,10 @@
       />
 
   <adapter
+      factory=".indexers.numberOfFolderishDocuments"
+      name="numberOfFolderishDocuments"
+      />
+  <adapter
       factory=".indexers.hasPreviewImage"
       name="hasPreviewImage"
       />

--- a/src/plone/volto/indexers.py
+++ b/src/plone/volto/indexers.py
@@ -1,7 +1,23 @@
 from Acquisition import aq_base
+from Products.CMFCore.utils import getToolByName
+
 from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer.decorator import indexer
 from plone.volto.behaviors.preview import IPreview
+from plone.volto.interfaces import IFolderishDocument
+
+
+@indexer(IFolderishDocument)
+def numberOfFolderishDocuments(obj):
+    """
+    How many FolderishDocument are contained in the FolderishDocument obj.
+    For UX affordance to show which pages aren't leaf nodes.
+    """
+    catalog = getToolByName(obj, 'portal_catalog')
+    query = {
+        'object_provides': IFolderishDocument.__identifier__,
+        'path': {'query':"/".join(obj.getPhysicalPath()), 'depth': 1}}
+    return len(catalog.unrestrictedSearchResults(query))
 
 
 @indexer(IPreview)

--- a/src/plone/volto/profiles/default/catalog.xml
+++ b/src/plone/volto/profiles/default/catalog.xml
@@ -4,4 +4,5 @@
   <column value="head_title" />
   <column value="hasPreviewImage" />
   <column value="image_field" />
+  <column value="numberOfFolderishDocuments" />
 </object>

--- a/src/plone/volto/profiles/default/metadata.xml
+++ b/src/plone/volto/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1016</version>
+  <version>1017</version>
   <dependencies>
     <dependency>profile-plone.restapi:blocks</dependency>
   </dependencies>


### PR DESCRIPTION
Add numberOfFolderishDocuments catalog metadata to allow UX affordance in folder contents in Volto.
