### PR TITLE
Traverse subblocks using IBlockVisitor instead of nested (de)serializers

### DIFF
--- a/news/127.bugfix
+++ b/news/127.bugfix
@@ -1,0 +1,1 @@
+Change the implementation for finding nested blocks to use an IBlockVisitor adapter. @davisagli

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,7 @@ setup(
         "plone.api",
         "Products.GenericSetup",
         "setuptools",
-        # TODO update pin once https://github.com/plone/plone.restapi/pull/1648 is released
-        "plone.restapi>=8.13.0",
+        "plone.restapi>=8.41.0",
         "plone.app.vocabularies>=4.3.0",
         "collective.monkeypatcher",
     ],

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "plone.api",
         "Products.GenericSetup",
         "setuptools",
+        # TODO update pin once https://github.com/plone/plone.restapi/pull/1648 is released
         "plone.restapi>=8.13.0",
         "plone.app.vocabularies>=4.3.0",
         "collective.monkeypatcher",

--- a/src/plone/volto/configure.zcml
+++ b/src/plone/volto/configure.zcml
@@ -59,44 +59,30 @@
       name="plone.volto.summary_serializer_metadata"
       />
 
-  <configure zcml:condition="have plonerestapi-7">
-    <subscriber
-        factory=".transforms.NestedResolveUIDDeserializer"
-        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.NestedResolveUIDDeserializerRoot"
-        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.NestedResolveUIDSerializer"
-        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.NestedResolveUIDSerializerRoot"
-        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.PreviewImageResolveUIDDeserializer"
-        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.PreviewImageResolveUIDDeserializerRoot"
-        provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.PreviewImageResolveUIDSerializer"
-        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
-        />
-    <subscriber
-        factory=".transforms.PreviewImageResolveUIDSerializerRoot"
-        provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
-        />
+  <subscriber
+      factory=".transforms.NestedBlocksVisitor"
+      provides="plone.restapi.interfaces.IBlockVisitor"
+      />
+  <subscriber
+      factory=".transforms.PreviewImageResolveUIDDeserializer"
+      provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
+      />
+  <subscriber
+      factory=".transforms.PreviewImageResolveUIDDeserializerRoot"
+      provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"
+      />
+  <subscriber
+      factory=".transforms.PreviewImageResolveUIDSerializer"
+      provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
+      />
+  <subscriber
+      factory=".transforms.PreviewImageResolveUIDSerializerRoot"
+      provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
+      />
 
-    <subscriber
-        factory=".linkintegrity.NestedBlockLinkRetriever"
-        provides="plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever"
-        />
-  </configure>
+  <subscriber
+      factory=".linkintegrity.NestedBlockLinkRetriever"
+      provides="plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever"
+      />
 
 </configure>

--- a/src/plone/volto/transforms.py
+++ b/src/plone/volto/transforms.py
@@ -2,112 +2,29 @@ from plone.restapi.behaviors import IBlocks
 from plone.restapi.deserializer.blocks import ResolveUIDDeserializerBase
 from plone.restapi.interfaces import IBlockFieldDeserializationTransformer
 from plone.restapi.interfaces import IBlockFieldSerializationTransformer
+from plone.restapi.interfaces import IBlockVisitor
 from plone.restapi.serializer.blocks import ResolveUIDSerializerBase
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
-from zope.component import subscribers
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
 
 
-class NestedResolveUIDDeserializerBase(object):
-    """The "url" smart block field for nested blocks
-
-    This is a generic handler. In all blocks, it converts any "url"
-    field from using resolveuid to an "absolute" URL
-    """
-
-    order = 1
-    block_type = None
+@implementer(IBlockVisitor)
+@adapter(Interface, IBrowserRequest)
+class NestedBlocksVisitor:
+    """Visit nested blocks in columns, hrefList, or slides."""
 
     def __init__(self, context, request):
-        self.context = context
-        self.request = request
+        pass
 
-    def _transform(self, block):
-        """this mutates the object directly"""
-
-        block_type = block.get("@type", "")
-        handlers = []
-        for h in subscribers(
-            (self.context, self.request), IBlockFieldDeserializationTransformer
-        ):
-            if h.block_type == block_type or h.block_type is None:
-                h.blockid = block.get("id", None)
-                handlers.append(h)
-
-        for handler in sorted(handlers, key=lambda h: h.order):
-            block = handler(block)
-
-        return block
-
-    def __call__(self, block):
-        for nested_name in ["columns", "hrefList", "slides"]:
-            nested_blocks = block.get(nested_name, [])
+    def __call__(self, block_value):
+        for nested_name in ("columns", "hrefList", "slides"):
+            nested_blocks = block_value.get(nested_name, [])
             if not isinstance(nested_blocks, list):
                 continue
-            for nested_block in nested_blocks:
-                self._transform(nested_block)
-        return block
-
-
-@adapter(IBlocks, IBrowserRequest)
-@implementer(IBlockFieldDeserializationTransformer)
-class NestedResolveUIDDeserializer(NestedResolveUIDDeserializerBase):
-    """Deserializer for content-types that implements IBlocks behavior"""
-
-
-@adapter(IPloneSiteRoot, IBrowserRequest)
-@implementer(IBlockFieldDeserializationTransformer)
-class NestedResolveUIDDeserializerRoot(NestedResolveUIDDeserializerBase):
-    """Deserializer for site root"""
-
-
-class NestedResolveUIDSerializerBase(object):
-    order = 1
-    block_type = None
-
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-
-    def _transform(self, block):
-        """this mutates the object directly"""
-
-        block_type = block.get("@type", "")
-        handlers = []
-        for h in subscribers(
-            (self.context, self.request), IBlockFieldSerializationTransformer
-        ):
-            if h.block_type == block_type or h.block_type is None:
-                h.blockid = block.get("id", None)
-                handlers.append(h)
-
-        for handler in sorted(handlers, key=lambda h: h.order):
-            block = handler(block)
-
-        return block
-
-    def __call__(self, block):
-        for nested_name in ["columns", "hrefList", "slides"]:
-            nested_blocks = block.get(nested_name, [])
-            if not isinstance(nested_blocks, list):
-                continue
-            for nested_block in nested_blocks:
-                self._transform(nested_block)
-        return block
-
-
-@adapter(IBlocks, IBrowserRequest)
-@implementer(IBlockFieldDeserializationTransformer)
-class NestedResolveUIDSerializer(NestedResolveUIDSerializerBase):
-    """Deserializer for content-types that implements IBlocks behavior"""
-
-
-@adapter(IPloneSiteRoot, IBrowserRequest)
-@implementer(IBlockFieldDeserializationTransformer)
-class NestedResolveUIDSerializerRoot(NestedResolveUIDSerializerBase):
-    """Deserializer for site root"""
+            yield from nested_blocks
 
 
 @adapter(IBlocks, IBrowserRequest)


### PR DESCRIPTION
Implement traversal of nested blocks for serialization and deserialization using an IBlockVisitor adapter instead of adapters for IBlockFieldDeserializationTransformer and IBlockFieldSerializationTransformer. The solution with IBlockVisitor can be used more generically when finding blocks for any purpose; it means a new way of finding sub-blocks can be added in one place rather than doing it once for serialization, once for deserialization, once for linkintegrity, once for searchable text, etc...

This should be fairly backwards-compatible, because we are changing how the blocks are found, but not which ones are found, what order they are found, or what adapters are applied once they are found.

Depends on https://github.com/plone/plone.restapi/pull/1648, which is why the tests are failing at the moment.