### PR TITLE
profile "plone.volto:multilingual": Add language german.

### DIFF
--- a/news/144.feature
+++ b/news/144.feature
@@ -1,1 +1,2 @@
+Import ILanguageSchema from plone.i18n.interfaces instead of Products.CMFPlone.interfaces.controlpanel. @ksuess
 profile "plone.volto:multilingual": Add language german. @ksuess

--- a/news/144.feature
+++ b/news/144.feature
@@ -1,0 +1,1 @@
+profile "plone.volto:multilingual": Add language german. @ksuess

--- a/src/plone/volto/profiles/multilingual/registry.xml
+++ b/src/plone/volto/profiles/multilingual/registry.xml
@@ -14,6 +14,7 @@
     <value>
       <element>it</element>
       <element>en</element>
+      <element>de</element>
     </value>
   </record>
 </registry>

--- a/src/plone/volto/profiles/multilingual/registry.xml
+++ b/src/plone/volto/profiles/multilingual/registry.xml
@@ -6,7 +6,6 @@
   >
     <value>en</value>
   </record>
-  <!-- Set language to it/en -->
   <record field="available_languages"
           interface="plone.i18n.interfaces.ILanguageSchema"
           name="plone.available_languages"

--- a/src/plone/volto/profiles/multilingual/registry.xml
+++ b/src/plone/volto/profiles/multilingual/registry.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <registry>
   <record field="default_language"
-          interface="Products.CMFPlone.interfaces.controlpanel.ILanguageSchema"
+          interface="plone.i18n.interfaces.ILanguageSchema"
           name="plone.default_language"
   >
     <value>en</value>
   </record>
   <!-- Set language to it/en -->
   <record field="available_languages"
-          interface="Products.CMFPlone.interfaces.controlpanel.ILanguageSchema"
+          interface="plone.i18n.interfaces.ILanguageSchema"
           name="plone.available_languages"
   >
     <value>


### PR DESCRIPTION
Before: ['it', 'en']

It would make writing tests for add-ons concerning multilinguality much easier if profile `plone.volto:multilingual` could be used and would provide also language german additional to italian and english.

A search shows the usage in plone/volto, but no more. If this profile is used in add-ons, this change would be a breaking change.
https://github.com/search?q=plone.volto%3Amultilingual&type=code&p=2