### PR TITLE
Do not set the nonfolderish_tabs registry to False

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.py?
 *.swp
 .*project
+.settings
 .Python
 # dirs
 bin/

--- a/news/145.bugfix
+++ b/news/145.bugfix
@@ -1,0 +1,1 @@
+Do not set the nonfolderish_tabs registry to False. @wesleybl

--- a/src/plone/volto/profiles/default/registry.xml
+++ b/src/plone/volto/profiles/default/registry.xml
@@ -1,11 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <registry>
-  <records interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema"
-           prefix="plone"
-  >
-    <value key="nonfolderish_tabs">False</value>
-  </records>
-
   <!-- This is for the elements in the root, not show the current item in navigation-->
   <record field="show_excluded_items"
           interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema"


### PR DESCRIPTION
The default setting of `True` will be set. With this, the content types in `displayed_types`  will appear in the menu, regardless of whether they are folderish. This mainly favored the Link type, which was not appearing in the menu because it was not folderish.

fixes #145