### PR TITLE
Fix for parent summary serializer when the parent has a  but it's empty

### DIFF
--- a/news/148.bugfix
+++ b/news/148.bugfix
@@ -1,3 +1,3 @@
-Fix for parent summary serializer when the parent has a but it's empty.
+Fix for preview_image_link image_scales adapter when the field is empty.
 Swap condition for `image_field` indexer, `preview_image_link` first, then the default `preview_image`
 [sneridagh]

--- a/news/148.bugfix
+++ b/news/148.bugfix
@@ -1,0 +1,3 @@
+Fix for parent summary serializer when the parent has a but it's empty.
+Swap condition for `image_field` indexer, `preview_image_link` first, then the default `preview_image`
+[sneridagh]

--- a/src/plone/volto/behaviors/preview_link.py
+++ b/src/plone/volto/behaviors/preview_link.py
@@ -70,3 +70,5 @@ class PreviewImageScalesFieldAdapter:
                     for value in values:
                         value["base_path"] = base_path
                 return values
+
+        return []

--- a/src/plone/volto/behaviors/preview_link.py
+++ b/src/plone/volto/behaviors/preview_link.py
@@ -56,16 +56,17 @@ class PreviewImageScalesFieldAdapter:
 
     def __call__(self):
         value = self.field.get(self.context)
-        linked_image = value.to_object
-        primary_field = IPrimaryFieldInfo(linked_image).field
-        serializer = queryMultiAdapter(
-            (primary_field, linked_image, self.request), IImageScalesFieldAdapter
-        )
-        if serializer is not None:
-            values = serializer()
-            if values:
-                portal_url = api.portal.get().absolute_url()
-                base_path = linked_image.absolute_url().replace(portal_url, "")
-                for value in values:
-                    value["base_path"] = base_path
-            return values
+        if value:
+            linked_image = value.to_object
+            primary_field = IPrimaryFieldInfo(linked_image).field
+            serializer = queryMultiAdapter(
+                (primary_field, linked_image, self.request), IImageScalesFieldAdapter
+            )
+            if serializer is not None:
+                values = serializer()
+                if values:
+                    portal_url = api.portal.get().absolute_url()
+                    base_path = linked_image.absolute_url().replace(portal_url, "")
+                    for value in values:
+                        value["base_path"] = base_path
+                return values

--- a/src/plone/volto/indexers.py
+++ b/src/plone/volto/indexers.py
@@ -24,13 +24,13 @@ def image_field_indexer(obj):
     base_obj = aq_base(obj)
 
     image_field = ""
-    if getattr(base_obj, "preview_image", False):
-        image_field = "preview_image"
-    elif (
+    if (
         getattr(base_obj, "preview_image_link", False)
         and not base_obj.preview_image_link.isBroken()
     ):
         image_field = "preview_image_link"
+    elif getattr(base_obj, "preview_image", False):
+        image_field = "preview_image"
     elif getattr(base_obj, "image", False):
         image_field = "image"
     return image_field


### PR DESCRIPTION
I tried it in a project with content (Document) having `preview_image_link` behavior, and it broke when creating childs because the parent has the empty field, and it tried to access `to_object` on it. 

https://github.com/kitconcept/kitconcept.com/actions/runs/8846612966/job/24369069918?pr=145#step:7:912

```
"traceback": [
    "File \"/app/lib/python3.11/site-packages/ZPublisher/WSGIPublisher.py\", line 181, in transaction_pubevents",
    "    yield",
    "",
    "  File \"/app/lib/python3.11/site-packages/ZPublisher/WSGIPublisher.py\", line 391, in publish_module",
    "    response = _publish(request, new_mod_info)",
    "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/ZPublisher/WSGIPublisher.py\", line 285, in publish",
    "    result = mapply(obj,",
    "             ^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/ZPublisher/mapply.py\", line 98, in mapply",
    "    return debug(object, args, context)",
    "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/ZPublisher/WSGIPublisher.py\", line 68, in call_object",
    "    return obj(*args)",
    "           ^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/rest/service.py\", line 21, in __call__",
    "    return self.render()",
    "           ^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/restapi/services/__init__.py\", line 19, in render",
    "    content = self.reply()",
    "              ^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/restapi/services/content/add.py\", line 115, in reply",
    "    serialized_obj = serializer()",
    "                     ^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/restapi/serializer/dxcontent.py\", line 178, in __call__",
    "    folder_metadata = super().__call__(version=version)",
    "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/restapi/serializer/dxcontent.py\", line 76, in __call__",
    "    parent_summary = getMultiAdapter(",
    "                     ^^^^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/restapi/serializer/summary.py\", line 99, in __call__",
    "    value = value()",
    "            ^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/app/contentlisting/realobject.py\", line 113, in image_scales",
    "    return getMultiAdapter((obj, self.request), IImageScalesAdapter)()",
    "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/Products/CMFPlone/image_scales/adapters.py\", line 30, in __call__",
    "    scales = serializer()",
    "             ^^^^^^^^^^^^",
    "",
    "  File \"/app/lib/python3.11/site-packages/plone/volto/behaviors/preview_link.py\", line 59, in __call__",
    "    linked_image = value.to_object",
    "                   ^^^^^^^^^^^^^^^"
  ],
  "type": "AttributeError"
}
```

Problem: this is in 6.0.11 :( 

Also, changed the order of the condition in the `image_field` index. Since the most probably is that you change from the default, existing, `preview_image` to the `preview_image_link`, is more sane to check the latter first, then the default.