### PR TITLE
Do not fail on startup when the requests library is missing.

### DIFF
--- a/news/152.bugfix
+++ b/news/152.bugfix
@@ -1,0 +1,5 @@
+Do not fail on startup when the ``requests`` library is missing.
+Conditionally load the views to migrate to Volto: only when the ``requests`` library is available.
+We don't want to make this a hard dependency.
+If you need the migration views, you should include the ``requests`` package yourself.
+[maurits]

--- a/src/plone/volto/browser/configure.zcml
+++ b/src/plone/volto/browser/configure.zcml
@@ -32,23 +32,25 @@
       zcml:condition="have plone-5"
       />
 
-  <browser:page
-      name="migrate_richtext"
-      for="zope.interface.Interface"
-      class=".migrate_richtext.MigrateRichTextToVoltoBlocks"
-      template="migrate_richtext.pt"
-      permission="cmf.ManagePortal"
-      zcml:condition="have plone-60"
-      />
+  <configure zcml:condition="installed requests">
+    <browser:page
+        name="migrate_richtext"
+        for="zope.interface.Interface"
+        class=".migrate_richtext.MigrateRichTextToVoltoBlocks"
+        template="migrate_richtext.pt"
+        permission="cmf.ManagePortal"
+        zcml:condition="have plone-60"
+        />
 
-  <browser:page
-      name="migrate_to_volto"
-      for="zope.interface.Interface"
-      class=".migrate_to_volto.MigrateToVolto"
-      template="migrate_to_volto.pt"
-      permission="cmf.ManagePortal"
-      zcml:condition="have plone-60"
-      />
+    <browser:page
+        name="migrate_to_volto"
+        for="zope.interface.Interface"
+        class=".migrate_to_volto.MigrateToVolto"
+        template="migrate_to_volto.pt"
+        permission="cmf.ManagePortal"
+        zcml:condition="have plone-60"
+        />
+  </configure>
 
   <browser:viewlet
       name="voltobackendwarning"


### PR DESCRIPTION
Conditionally load the views to migrate to Volto: only when the ``requests`` library is available. We don't want to make this a hard dependency.
If you need the migration views, you should include the ``requests`` package yourself. Fixes https://github.com/plone/plone.volto/issues/152