### PR TITLE
setup.py: specify the encoding, otherwise it fails on Windows.

### DIFF
--- a/mx.ini
+++ b/mx.ini
@@ -10,5 +10,5 @@ version-overrides =
 
 [plone.distribution]
 url = https://github.com/plone/plone.distribution.git
-branch = remove-classic-distribution
+branch = main
 extras = test

--- a/news/+ignore.internal
+++ b/news/+ignore.internal
@@ -1,0 +1,2 @@
+setup.py: specify the encoding, otherwise it fails on Windows.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@ from setuptools import find_packages
 from setuptools import setup
 
 
+# We must specify the encoding, otherwise it fails on Windows as it defaults to cp1252.
 long_description = "\n\n".join(
     [
-        open("README.md").read(),
-        open("CHANGES.md").read(),
+        open("README.md", encoding="utf-8").read(),
+        open("CHANGES.md", encoding="utf-8").read(),
     ]
 )
 


### PR DESCRIPTION
See https://github.com/plone/buildout.coredev/actions/runs/11232477204/job/31224151602#step:7:545