### PR TITLE
Fix mx.ini to ignore plone.volto.

### DIFF
--- a/mx.ini
+++ b/mx.ini
@@ -5,8 +5,8 @@
 
 [settings]
 main-package = -e .[test]
-version-overrides =
-    plone.volto==5.0.0b2.dev0
+ignores =
+    plone.volto
 
 [plone.distribution]
 url = https://github.com/plone/plone.distribution.git


### PR DESCRIPTION
We had plone.volto in the version-overrides, which works, but then you have to edit this line after each release. This is what the 'ignores' keyword is for.
