### PR TITLE
Remove unnecessary zcml conditions

### DIFF
--- a/news/167.internal
+++ b/news/167.internal
@@ -1,0 +1,1 @@
+Remove unused ZCML conditions. @davisagli

--- a/src/plone/volto/behaviors/configure.zcml
+++ b/src/plone/volto/behaviors/configure.zcml
@@ -1,7 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.volto"
     >
 
@@ -17,15 +16,13 @@
       provides=".preview.IPreview"
       />
 
-  <configure zcml:condition="have plone-60">
-    <plone:behavior
-        name="volto.preview_image_link"
-        title="Preview Image Link"
-        description="Preview image for listings based on links"
-        provides=".preview_link.IPreviewLink"
-        />
-    <adapter factory=".preview_link.PreviewImageScalesFieldAdapter" />
-  </configure>
+  <plone:behavior
+      name="volto.preview_image_link"
+      title="Preview Image Link"
+      description="Preview image for listings based on links"
+      provides=".preview_link.IPreviewLink"
+      />
+  <adapter factory=".preview_link.PreviewImageScalesFieldAdapter" />
 
   <plone:behavior
       name="volto.navtitle"

--- a/src/plone/volto/browser/configure.zcml
+++ b/src/plone/volto/browser/configure.zcml
@@ -19,7 +19,6 @@
       allowed_attributes="breadcrumbs"
       permission="zope.Public"
       layer="plone.volto.interfaces.IPloneVoltoCoreLayer"
-      zcml:condition="have plone-5"
       />
 
   <browser:page
@@ -29,7 +28,6 @@
       allowed_attributes="topLevelTabs"
       permission="zope.Public"
       layer="plone.volto.interfaces.IPloneVoltoCoreLayer"
-      zcml:condition="have plone-5"
       />
 
   <configure zcml:condition="installed requests">
@@ -39,7 +37,6 @@
         class=".migrate_richtext.MigrateRichTextToVoltoBlocks"
         template="migrate_richtext.pt"
         permission="cmf.ManagePortal"
-        zcml:condition="have plone-60"
         />
 
     <browser:page
@@ -48,7 +45,6 @@
         class=".migrate_to_volto.MigrateToVolto"
         template="migrate_to_volto.pt"
         permission="cmf.ManagePortal"
-        zcml:condition="have plone-60"
         />
   </configure>
 
@@ -59,7 +55,6 @@
       template="voltobackendwarning.pt"
       permission="zope2.View"
       layer="plone.volto.interfaces.IPloneVoltoCoreLayer"
-      zcml:condition="have plone-60"
       />
 
 </configure>

--- a/src/plone/volto/configure.zcml
+++ b/src/plone/volto/configure.zcml
@@ -5,7 +5,6 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:plone="http://namespaces.plone.org/plone"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.volto"
     >
 

--- a/src/plone/volto/dependencies.zcml
+++ b/src/plone/volto/dependencies.zcml
@@ -1,7 +1,4 @@
-<configure
-    xmlns="http://namespaces.zope.org/zope"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
-    >
+<configure xmlns="http://namespaces.zope.org/zope">
 
   <include
       package="Products.GenericSetup"

--- a/src/plone/volto/overrides.zcml
+++ b/src/plone/volto/overrides.zcml
@@ -1,7 +1,4 @@
-<configure
-    xmlns="http://namespaces.zope.org/zope"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
-    >
+<configure xmlns="http://namespaces.zope.org/zope">
 
   <utility
       name="plone.app.vocabularies.Keywords"

--- a/src/plone/volto/patches.zcml
+++ b/src/plone/volto/patches.zcml
@@ -1,7 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:monkey="http://namespaces.plone.org/monkey"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.volto"
     >
 
@@ -20,7 +19,6 @@
       class="Products.CMFPlone.browser.login.password_reset.PasswordResetToolView"
       docstringWarning="True"
       description="Patch password reset tool construct URL to cater for different frontend domain"
-      zcml:condition="have plone-52"
       />
 
 </configure>


### PR DESCRIPTION
No longer needed because the package already dropped support for Plone < 6.1