### PR TITLE
Fix remoteUrl value for non Creators

### DIFF
--- a/news/159.bugfix
+++ b/news/159.bugfix
@@ -1,0 +1,1 @@
+Fix output of `getRemoteUrl` value for non `Creators`. @ichim-david

--- a/news/159.bugfix
+++ b/news/159.bugfix
@@ -1,1 +1,1 @@
-Fix output of `getRemoteUrl` value for non `Creators`. @ichim-david
+Resolve UID-based internal links in navigation tabs. @ichim-david

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = "\n\n".join(
 
 setup(
     name="plone.volto",
-    version="5.0.4.dev1",
+    version="5.0.4.dev0",
     description="Volto integration add-on for Plone",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = "\n\n".join(
 
 setup(
     name="plone.volto",
-    version="5.0.4.dev0",
+    version="5.0.4.dev1",
     description="Volto integration add-on for Plone",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/plone/volto/browser/navigation.py
+++ b/src/plone/volto/browser/navigation.py
@@ -4,6 +4,7 @@ from plone.base import utils
 from plone.base.interfaces import INavigationSchema
 from plone.base.navigationroot import get_navigation_root
 from plone.registry.interfaces import IRegistry
+from plone.restapi.serializer.utils import uid_to_url
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.browser.interfaces import INavigationTabs
 from Products.CMFPlone.browser.navigation import get_id
@@ -84,7 +85,7 @@ class CatalogNavigationTabs(BrowserView):
 
         def _get_url(item):
             if item.getRemoteUrl and not member == item.Creator:
-                return (get_id(item), item.getRemoteUrl)
+                return (get_id(item), uid_to_url(item.getRemoteUrl))
             return get_view_url(item)
 
         context_path = "/".join(context.getPhysicalPath())


### PR DESCRIPTION
When you add a link content type and you allow it to be part of the portal tabs navigation, Other users will see resolveUID link instead of seeing the actual result of calling resolveUID.
You can see this clearly by taking a look at this screenshot on VoltoDemo where I can reproduce the issue.

Url Nav is a link and it's remoteUrl shows up as what you can see in the screenshot.

![resolve-uid-nav](https://github.com/user-attachments/assets/d32bf9e0-0230-48fd-a310-1a42f8ac19f4)
